### PR TITLE
ACC auto resume

### DIFF
--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -152,6 +152,10 @@ class CarController(object):
       # If using stock ACC, spam cancel command to kill gas when OP disengages.
       if pcm_cancel_cmd:
         can_sends.append(hondacan.create_cancel_command(idx))
+
+      if CS.stopped:
+        can_sends.append(hondacan.create_resume_command(idx))
+
     else:
       # Send gas and brake commands.
       if (frame % 2) == 0:

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -192,6 +192,8 @@ class CarState(object):
     self.left_blinker_on = 0
     self.right_blinker_on = 0
 
+    self.stopped = 0
+
     # vEgo kalman filter
     dt = 0.01
     # Q = np.matrix([[10.0, 0.0], [0.0, 100.0]])
@@ -233,6 +235,8 @@ class CarState(object):
     self.steer_not_allowed = cp.vl["STEER_STATUS"]['STEER_STATUS'] != 0
     self.brake_error = cp.vl["STANDSTILL"]['BRAKE_ERROR_1'] or cp.vl["STANDSTILL"]['BRAKE_ERROR_2']
     self.esp_disabled = cp.vl["VSA_STATUS"]['ESP_DISABLED']
+
+    self.stopped = cp.vl["ACC_HUD"]['CRUISE_SPEED'] == 252.
 
     # calc best v_ego estimate, by averaging two opposite corners
     self.v_wheel_fl = cp.vl["WHEEL_SPEEDS"]['WHEEL_SPEED_FL'] * CV.KPH_TO_MS

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -150,3 +150,6 @@ def create_radar_commands(v_ego, car_fingerprint, idx):
 
 def create_cancel_command(idx):
   return make_can_msg(0x296, "\x40\x00\x00", idx, 0)
+
+def create_resume_command(idx):
+  return make_can_msg(0x296, "\x80\x00\x00", idx, 0)

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -211,7 +211,7 @@ def state_transition(CS, CP, state, events, soft_disable_timer, v_cruise_kph, AM
 
 
 def state_control(plan, CS, CP, state, events, v_cruise_kph, v_cruise_kph_last, AM, rk,
-                  awareness_status, PL, LaC, LoC, VM, angle_offset, rear_view_allowed, 
+                  awareness_status, PL, LaC, LoC, VM, angle_offset, rear_view_allowed,
                   rear_view_toggle, passive):
   # Given the state, this function returns the actuators
 
@@ -266,9 +266,9 @@ def state_control(plan, CS, CP, state, events, v_cruise_kph, v_cruise_kph_last, 
                                       CS.steeringPressed)
 
   # *** gas/brake PID loop ***
-  actuators.gas, actuators.brake = LoC.update(active, CS.vEgo, CS.brakePressed, CS.standstill, CS.cruiseState.standstill,
-                                              v_cruise_kph, plan.vTarget, plan.vTargetFuture, plan.aTarget,
-                                              CP, PL.lead_1)
+  # actuators.gas, actuators.brake = LoC.update(active, CS.vEgo, CS.brakePressed, CS.standstill, CS.cruiseState.standstill,
+  #                                             v_cruise_kph, plan.vTarget, plan.vTargetFuture, plan.aTarget,
+  #                                             CP, PL.lead_1)
 
   # *** steering PID loop ***
   actuators.steer, actuators.steerAngle = LaC.update(active, CS.vEgo, CS.steeringAngle,


### PR DESCRIPTION
This is probably not complete, but it works great on my Accord.

It auto resumes when "STOPPED" is shown on the hud.

I also disabled `LoC.update` because is not needed for Bosch cars, and now my eon runs faster and the fan does not run too often. I'll probably have to add a condition to get this merged, but in the meantime other Accord users can use this.