### PR TITLE
Fix for steering loss

### DIFF
--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -132,6 +132,9 @@ class CarController(object):
     apply_brake = int(clip(self.brake_last * BRAKE_MAX, 0, BRAKE_MAX - 1))
     apply_steer = int(clip(-actuators.steer * STEER_MAX, -STEER_MAX, STEER_MAX))
 
+    if apply_steer == 0 and CS.steer_not_allowed is False:
+      apply_steer = 1
+
     # any other cp.vl[0x18F]['STEER_STATUS'] is common and can happen during user override. sending 0 torque to avoid EPS sending error 5
     if CS.steer_not_allowed:
       apply_steer = 0


### PR DESCRIPTION
Fix does work with the following caveat, anytime you are in motion without OP enabled, dash errors are thrown.  Does not interfere with activating OP.