### PR TITLE
Fixes passive mode on accord, cr-v, and hatchback

### DIFF
--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && apt-get install -y build-essential clang vim screen wget bzip2 git libglib2.0-0 python-pip capnproto libcapnp-dev libzmq5-dev libffi-dev libusb-1.0-0
-RUN pip install numpy==1.11.2 scipy==0.18.1 matplotlib==2.1.2
+RUN pip install numpy==1.11.2 scipy==0.18.1 matplotlib==2.2.3
 
 COPY requirements_openpilot.txt /tmp/
 RUN pip install -r /tmp/requirements_openpilot.txt


### PR DESCRIPTION
Enables passive mode for bosch vehicles.

In order to use Honda Sensing in any bosch, you must unplug your EON which means you can't record drives. This PR detects when giraffe switch is high and sets passive mode automatically.